### PR TITLE
Changed logo to use the square image for small and large

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -26,7 +26,7 @@
     "keywords": ["cloudflare", "dns", "http", "security", "cdn"],
     "logos": {
       "small": "img/cf_icon.png",
-      "large": "img/cf_logo.png"
+      "large": "img/cf_icon.png"
     },
     "links": [
       {"name": "Project site", "url": "https://github.com/cloudflare/cloudflare-grafana-app"},

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -26,7 +26,7 @@
     "keywords": ["cloudflare", "dns", "http", "security", "cdn"],
     "logos": {
       "small": "img/cf_icon.png",
-      "large": "img/cf_logo.png"
+      "large": "img/cf_icon.png"
     },
     "links": [
       {"name": "Project site", "url": "https://github.com/cloudflare/cloudflare-grafana-app"},


### PR DESCRIPTION
In both cases, the logo needs to be a square image. Used the existing asset listed for small, which will hold up just fine at 100x100 (though if you have an SVG, go ahead and use that in the future!)